### PR TITLE
add space only after Latin script punctuation.

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -406,16 +406,12 @@ fn main() -> Result<(), Box<dyn Error>> {
                                     }
                                 };
 
-                                // if let Some(last_char) = transcription.chars().last() {
-                                //     if last_char != '.'
-                                //         && last_char != '?'
-                                //         && last_char != '!'
-                                //         && last_char != ','
-                                //     {
-                                //         transcription.push('.');
-                                //     }
-                                // }
-                                transcription.push(' ');
+                                if let Some(last_char) = transcription.chars().last() {
+                                    if ['.', '?', '!', ','].contains(&last_char) {
+                                        println!("adding space to end of transcription");
+                                        transcription.push(' ');
+                                    }
+                                }
 
                                 enigo.key_sequence(&transcription);
                             } else {


### PR DESCRIPTION
This is a hack for now, but is better than always adding a space for any language. I'll probably have a large language model figure out what punctuation to add later.