### PR TITLE
🐛Add timeout

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ repository = "https://github.com/sloganking/desk-talk"
 [dependencies]
 anyhow = "1.0.75"
 async-openai = "0.14.3"
+async-std = "1.12.0"
 clap = { version = "4.4.6", features = ["derive"] }
 cpal = "0.15.2"
 dotenvy = "0.15.7"


### PR DESCRIPTION
Previously, the program would sometimes not return the result of a keypress and thus stop functioning afterwards until it was restarted. Hopefully, this timeout fixes that.