### PR TITLE
Fix project rename in CLI hint

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -85,7 +85,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         Some(subcommand) => {
             match subcommand {
                 SubCommands::ShowKeyPresses => {
-                    println!("Press keys to see their codes. Press Ctrl+C to exit. Once you've figured out what key you want to use for push to talk, pass it to easy-tran using the --ptt-key argument. Or pass the number to the --special-ptt-key argument if the key is Unknown(number).");
+                    println!("Press keys to see their codes. Press Ctrl+C to exit. Once you've figured out what key you want to use for push to talk, pass it to desk-talk using the --ptt-key argument. Or pass the number to the --special-ptt-key argument if the key is Unknown(number).");
 
                     fn show_keys_callback(event: Event) {
                         if let rdev::EventType::KeyPress(key) = event.event_type {


### PR DESCRIPTION
## Summary
- update ptt hint from easy-tran to desk-talk

## Testing
- `cargo test` *(fails: The system library `alsa` required by crate `alsa-sys` was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68412518b0b08332af76a8ae8937b621